### PR TITLE
Fix leaking BLE event listeners after multiple connect/disconnect events

### DIFF
--- a/source/accessory.js
+++ b/source/accessory.js
@@ -116,6 +116,7 @@ BluetoothAccessory.prototype.disconnect = function (error) {
     this.homebridgeAccessory.removeAllListeners('identify');
     this.homebridgeAccessory.updateReachability(false);
     this.homebridgeAccessory = null;
+    this.nobleAccessory.removeAllListeners();
     this.nobleAccessory = null;
     this.log.info(this.prefix, "Disconnected");
   }


### PR DESCRIPTION
Seems as though if the BLE device on the pi disconnects before discovery, listeners are left. These become active later on when an actual connect to the device is successful and fires at the same time. This can cause a memory leak as well as issues where the system does not get a proper read from the device and the user sees the device as non responsive in HomeKit.

Fix #4.